### PR TITLE
POSHI-294 | main

### DIFF
--- a/src/lib/languageFeatureProviders/DefinitionProviderImpl.ts
+++ b/src/lib/languageFeatureProviders/DefinitionProviderImpl.ts
@@ -116,7 +116,14 @@ const getMethodLocations = async (
 	});
 
 	return lines.map((s) => {
-		const [filepath, lineNumber, columnNumber] = s.split(':');
+		if (process.platform === "win32") {
+			var [drive, filepath, lineNumber,columnNumber] = s.split(':');
+
+			var filepath = drive + ":" + filepath;
+		}
+		else {
+			var [filepath, lineNumber, columnNumber] = s.split(':');
+		}
 
 		return new vscode.Location(
 			vscode.Uri.from({

--- a/src/lib/languageFeatureProviders/DefinitionProviderImpl.ts
+++ b/src/lib/languageFeatureProviders/DefinitionProviderImpl.ts
@@ -117,19 +117,26 @@ const getMethodLocations = async (
 
 	return lines.map((s) => {
 		if (process.platform === "win32") {
-			var [drive, filepath, lineNumber,columnNumber] = s.split(':');
+			const splits = s.split(':');
 
-			var filepath = drive + ":" + filepath;
+			if (splits[0].includes("wsl")) {
+				var filepath = splits[0];
+				var lineNumber = splits[1];
+				var columnNumber = splits[2];
+			}
+			else {
+				var filepath = splits[0] + ":" + splits[1];
+				var lineNumber = splits[2];
+				var columnNumber = splits[3];
+
+			}
 		}
 		else {
 			var [filepath, lineNumber, columnNumber] = s.split(':');
 		}
 
 		return new vscode.Location(
-			vscode.Uri.from({
-				path: filepath,
-				scheme: 'file',
-			}),
+			vscode.Uri.file(filepath),
 
 			new vscode.Position(
 				Number(lineNumber) - 1,


### PR DESCRIPTION
https://issues.liferay.com/browse/POSHI-294

Hi @drewbrokke,
The users cannot use method definitions and code intellisense on windows OS.

1. The native windows File System
2. The [wsl](https://docs.microsoft.com/en-us/windows/wsl/install) (windows subsystem for linux)  File System

I sent a possible solution here. Would you mind having a look at? Thanks